### PR TITLE
chore: make it possible to install older versions of the heroku cli

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -1,0 +1,21 @@
+on:
+  pull_request:
+    branches: ['*']
+  push:
+    branches: ['main']
+
+jobs:
+  selfcheck:
+    runs-on: ubuntu-24.04
+    name: Test Action
+    strategy:
+      matrix:
+        version: [latest, 9.5.1, 10.0.0]
+    steps:
+      # To use this repository's private action,
+      # you must check out the repository
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: ./
+        with:
+          version: ${{matrix.version}}

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -19,3 +19,10 @@ jobs:
       - uses: ./
         with:
           version: ${{matrix.version}}
+  lint-with-pre-commit:
+    runs-on: ubuntu-24.04
+    name: Lint with pre-commit
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: instrumentl/pre-commit-action@v4

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -3,14 +3,17 @@ on:
     branches: ['*']
   push:
     branches: ['main']
+  schedule:
+  - cron: "18 18 * * 1"
 
 jobs:
   selfcheck:
-    runs-on: ubuntu-24.04
     name: Test Action
     strategy:
       matrix:
+        runner: [ubuntu-22.04, ubuntu-24.04, ubuntu-latest]
         version: [latest, 9.5.1, 10.0.0]
+    runs-on: ${{ matrix.runner }}
     steps:
       # To use this repository's private action,
       # you must check out the repository

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-yaml
+  - id: check-added-large-files
+  - id: fix-byte-order-marker
+  - id: check-json
+  - id: check-merge-conflict
+- repo: https://github.com/Mateusz-Grzelinski/actionlint-py
+  rev: v1.7.4.20
+  hooks:
+  - id: actionlint
+    additional_dependencies: [ pyflakes>=3.0.1, shellcheck-py>=0.9.0.5 ]

--- a/README.md
+++ b/README.md
@@ -2,4 +2,9 @@ This is a small GitHub action that runs the Heroku installer to set up the `hero
 
 ```yaml
 - uses: instrumentl/setup-heroku@v1
+  with:
+    # Pass "latest" here to use whatever heroku has made the default; otherwise, you
+    # can pass a specific version (e.g., '9.5.1') which must exactly match a version
+    # string in the undocumented heroku-cli manifest
+    version: 'latest'
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,63 @@
 name: 'Set up Heroku'
 description: 'Set up the Heroku CLI'
+inputs:
+  version:
+    description: "Version to install"
+    required: true
+    default: "latest"
 runs:
   using: "composite"
   steps:
-  - name: "Ensure GPG installed"
+  - name: "Ensure dependencies are installed"
     shell: bash
-    run: "if ! command -v gpg; then apt-get install --no-install-recommends gnupg2 ; fi"
+    run: |
+      if ! command -v gpg; then apt-get install --no-install-recommends gnupg2 ; fi
+      if ! command -v curl; then apt-get install --no-install-recommends curl ; fi
+      if ! command -v jq; then apt-get install --no-install-recommends jq ; fi
   - name: "Install Heroku CLI"
     shell: bash
-    run: "curl -f https://cli-assets.heroku.com/install-ubuntu.sh | sh"
+    env:
+      version: ${{ inputs.version }}
+    run: |
+      set -euo pipefail
+
+      wd="$(mktemp -d)"
+      on_exit() {
+        status=$?
+        [[ -n "$wd" ]] && rm -rf "$wd"
+        exit $status
+      }
+
+      trap on_exit EXIT INT TERM
+      raw_machine="$(uname -m)"
+      if [[ "$raw_machine" = "aarch64" ]]; then
+        machine="arm"
+      elsif [[ "$raw_machine" = "x86_64" ]]; then
+        machine="x64"
+      else
+        echo >&2 "Unhandled machine type $raw_machine"
+        exit 1
+      fi
+
+      curl -fqs -o "$wd/versions.json" "https://cli-assets.heroku.com/versions/heroku-linux-${machine}-tar-gz.json"
+      if [[ "$version" = "latest" ]]; then
+        url="https://cli-assets.heroku.com/channels/stable/heroku-linux-${machine}.tar.gz"
+      else
+        url="$(jq -cr '.["'"${version}"'"]' < versions.json)"
+      fi
+      if [[ -z "$url" ]] || [[ "$url" = "null" ]]; then
+        echo >&2 "Could not find download for ${version} for ${machine}"
+        exit 1
+      fi
+      curl -o "$wd/heroku.tar.gz" "$url"
+
+      mkdir -p /usr/local/lib
+      rm -rf /usr/local/lib/heroku
+      tar -xzf "$wd/heroku.tar.gz" -C /usr/local/lib
+      rm -f /usr/local/bin/heroku
+      ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
+
+      /usr/local/lib/heroku/bin/node -v || rm /usr/local/lib/heroku/bin/node
   - name: "Test that it runs correctly"
     run: "heroku version"
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,7 @@ runs:
         echo >&2 "Could not find download for ${version} for ${machine}"
         exit 1
       fi
+      echo "url=${url}" >> "$GITHUB_OUTPUT"
   - name: Cache CLI
     id: cache-cli
     uses: actions/cache@v4
@@ -57,6 +58,7 @@ runs:
       path: /tmp/heroku-${{ inputs.version }}.tar.gz
       key: ${{ runner.os }}-${{ runner.arch }}-${{ steps.get_url.outputs.url }}
   - name: "Download CLI"
+    shell: bash
     if: steps.cache.outputs.cache-hit != 'true'
     run: |
       curl -o "/tmp/heroku-${{ inputs.version }}.tar.gz" -sq "${{ steps.get_url.outputs.url }}"

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
       if [[ "$version" = "latest" ]]; then
         url="https://cli-assets.heroku.com/channels/stable/heroku-linux-${machine}.tar.gz"
       else
-        url="$(jq -cr '.["'"${version}"'"]' < versions.json)"
+        url="$(jq -cr '.["'"${version}"'"]' < "$wd/versions.json")"
       fi
       if [[ -z "$url" ]] || [[ "$url" = "null" ]]; then
         echo >&2 "Could not find download for ${version} for ${machine}"

--- a/action.yml
+++ b/action.yml
@@ -52,14 +52,14 @@ runs:
       fi
       echo "url=${url}" >> "$GITHUB_OUTPUT"
   - name: Cache CLI
-    id: cache-cli
+    id: cache_cli
     uses: actions/cache@v4
     with:
       path: /tmp/heroku-${{ inputs.version }}.tar.gz
       key: ${{ runner.os }}-${{ runner.arch }}-${{ steps.get_url.outputs.url }}
   - name: "Download CLI"
     shell: bash
-    if: steps.cache.outputs.cache-hit != 'true'
+    if: steps.cache_cli.outputs.cache-hit != 'true'
     run: |
       curl -o "/tmp/heroku-${{ inputs.version }}.tar.gz" -sq "${{ steps.get_url.outputs.url }}"
   - name: "Install Heroku CLI"

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
       raw_machine="$(uname -m)"
       if [[ "$raw_machine" = "aarch64" ]]; then
         machine="arm"
-      elsif [[ "$raw_machine" = "x86_64" ]]; then
+      elif [[ "$raw_machine" = "x86_64" ]]; then
         machine="x64"
       else
         echo >&2 "Unhandled machine type $raw_machine"

--- a/action.yml
+++ b/action.yml
@@ -11,9 +11,9 @@ runs:
   - name: "Ensure dependencies are installed"
     shell: bash
     run: |
-      if ! command -v gpg; then apt-get install --no-install-recommends gnupg2 ; fi
-      if ! command -v curl; then apt-get install --no-install-recommends curl ; fi
-      if ! command -v jq; then apt-get install --no-install-recommends jq ; fi
+      if ! command -v gpg; then sudo -n apt-get install --no-install-recommends gnupg2 ; fi
+      if ! command -v curl; then sudo -n apt-get install --no-install-recommends curl ; fi
+      if ! command -v jq; then sudo -n apt-get install --no-install-recommends jq ; fi
   - name: "Install Heroku CLI"
     shell: bash
     env:
@@ -49,15 +49,15 @@ runs:
         echo >&2 "Could not find download for ${version} for ${machine}"
         exit 1
       fi
-      curl -o "$wd/heroku.tar.gz" "$url"
+      curl -o "$wd/heroku.tar.gz" -sq "$url"
 
-      rm -rf /usr/local/lib/heroku
-      mkdir -p /usr/local/lib/heroku
-      tar -C /usr/local/lib -xpzf "$wd/heroku.tar.gz"
-      rm -f /usr/local/bin/heroku
-      ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
+      sudo -n rm -rf /usr/local/lib/heroku
+      sudo -n mkdir -p /usr/local/lib/heroku
+      sudo -n tar -C /usr/local/lib -xpzf "$wd/heroku.tar.gz"
+      sudo -n rm -f /usr/local/bin/heroku
+      sudo -n ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
 
-      /usr/local/lib/heroku/bin/node -v || rm /usr/local/lib/heroku/bin/node
+      /usr/local/lib/heroku/bin/node -v || sudo -n rm /usr/local/lib/heroku/bin/node
   - name: "Test that it runs correctly"
     run: "heroku version"
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -51,9 +51,9 @@ runs:
       fi
       curl -o "$wd/heroku.tar.gz" "$url"
 
-      mkdir -p /usr/local/lib
       rm -rf /usr/local/lib/heroku
-      tar -xzf "$wd/heroku.tar.gz" -C /usr/local/lib
+      mkdir -p /usr/local/lib/heroku
+      tar -C /usr/local/lib -xpzf "$wd/heroku.tar.gz"
       rm -f /usr/local/bin/heroku
       ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
 

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,8 @@ runs:
       if ! command -v gpg; then sudo -n apt-get install --no-install-recommends gnupg2 ; fi
       if ! command -v curl; then sudo -n apt-get install --no-install-recommends curl ; fi
       if ! command -v jq; then sudo -n apt-get install --no-install-recommends jq ; fi
-  - name: "Install Heroku CLI"
+  - name: "Determine download url"
+    id: get_url
     shell: bash
     env:
       version: ${{ inputs.version }}
@@ -49,11 +50,24 @@ runs:
         echo >&2 "Could not find download for ${version} for ${machine}"
         exit 1
       fi
-      curl -o "$wd/heroku.tar.gz" -sq "$url"
+  - name: Cache CLI
+    id: cache-cli
+    uses: actions/cache@v4
+    with:
+      path: /tmp/heroku-${{ inputs.version }}.tar.gz
+      key: ${{ runner.os }}-${{ runner.arch }}-${{ steps.get_url.outputs.url }}
+  - name: "Download CLI"
+    if: steps.cache.outputs.cache-hit != 'true'
+    run: |
+      curl -o "/tmp/heroku-${{ inputs.version }}.tar.gz" -sq "${{ steps.get_url.outputs.url }}"
+  - name: "Install Heroku CLI"
+    shell: bash
+    run: |
+      set -euo pipefail
 
       sudo -n rm -rf /usr/local/lib/heroku
       sudo -n mkdir -p /usr/local/lib/heroku
-      sudo -n tar -C /usr/local/lib -xpzf "$wd/heroku.tar.gz"
+      sudo -n tar -C /usr/local/lib -xpzf "/tmp/heroku-${{ inputs.version }}.tar.gz"
       sudo -n rm -f /usr/local/bin/heroku
       sudo -n ln -s /usr/local/lib/heroku/bin/heroku /usr/local/bin/heroku
 


### PR DESCRIPTION
v10.0.0 broke the ability to release container apps. This PR allows us to pin a specific version of the CLI, using an undocumented manifest file that I'm sure Heroku will never move or break.

https://app.asana.com/0/1203152445520316/1208977255156253/f
